### PR TITLE
removed MULTI_CLIENT from example .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ An example of `.env` file:
 API_ID=452525
 API_HASH=esx576f8738x883f3sfzx83
 BOT_TOKEN=55838383:yourtbottokenhere
-MULTI_CLIENT=True
 MULTI_TOKEN1=55838383:yourfirstmulticlientbottokenhere
 MULTI_TOKEN2=55838383:yoursecondmulticlientbottokenhere
 MULTI_TOKEN3=55838383:yourthirdmulticlientbottokenhere
@@ -113,7 +112,7 @@ HAS_SSL=False
 
 `BOT_TOKEN` : Get the bot token from [@BotFather](https://telegram.dog/BotFather)
 
-`BIN_CHANNEL` : Create a new channel (private/public), post something in your channel. Forward that post to [@missrose_bot](https://telegram.dog/MissRose_bot) and **reply** `\id`. Now copy paste the forwarded channel ID in this field. 
+`BIN_CHANNEL` : Create a new channel (private/public), post something in your channel. Forward that post to [@missrose_bot](https://telegram.dog/MissRose_bot) and **reply** `/id`. Now copy paste the forwarded channel ID in this field. 
 
 ### For MultiClient
 


### PR DESCRIPTION
- Removed MULTI_CLIENT=True
  It make's confusion and some people try to Disable MULTI_CLIENT by changing the Value to False in .env file which won't work
- Changed \id to /id