### PR TITLE
Fix for files without filename

### DIFF
--- a/WebStreamer/server/stream_routes.py
+++ b/WebStreamer/server/stream_routes.py
@@ -12,6 +12,7 @@ from aiohttp.http_exceptions import BadStatusLine
 from WebStreamer.bot import multi_clients, work_loads
 from WebStreamer.server.exceptions import FIleNotFound, InvalidHash
 from WebStreamer import Var, utils, StartTime, __version__, StreamBot
+from WebStreamer.utils import get_name
 
 logger = logging.getLogger("routes")
 
@@ -116,21 +117,11 @@ async def media_streamer(request: web.Request, message_id: int, secure_hash: str
         file_id, index, offset, first_part_cut, last_part_cut, part_count, chunk_size
     )
     mime_type = file_id.mime_type
-    file_name = file_id.file_name
+    file_name = get_name(file_id)
     disposition = "attachment"
 
-    if mime_type:
-        if not file_name:
-            try:
-                file_name = f"{secrets.token_hex(2)}.{mime_type.split('/')[1]}"
-            except (IndexError, AttributeError):
-                file_name = f"{secrets.token_hex(2)}.unknown"
-    else:
-        if file_name:
-            mime_type = mimetypes.guess_type(file_id.file_name)
-        else:
-            mime_type = "application/octet-stream"
-            file_name = f"{secrets.token_hex(2)}.unknown"
+    if not mime_type:
+        mime_type = mimetypes.guess_type(file_name)[0] or "application/octet-stream"
 
     if "video/" in mime_type or "audio/" in mime_type or "/html" in mime_type:
         disposition = "inline"

--- a/WebStreamer/server/stream_routes.py
+++ b/WebStreamer/server/stream_routes.py
@@ -12,7 +12,6 @@ from aiohttp.http_exceptions import BadStatusLine
 from WebStreamer.bot import multi_clients, work_loads
 from WebStreamer.server.exceptions import FIleNotFound, InvalidHash
 from WebStreamer import Var, utils, StartTime, __version__, StreamBot
-from WebStreamer.utils import get_name
 
 logger = logging.getLogger("routes")
 
@@ -117,7 +116,7 @@ async def media_streamer(request: web.Request, message_id: int, secure_hash: str
         file_id, index, offset, first_part_cut, last_part_cut, part_count, chunk_size
     )
     mime_type = file_id.mime_type
-    file_name = get_name(file_id)
+    file_name = utils.get_name(file_id)
     disposition = "attachment"
 
     if not mime_type:

--- a/WebStreamer/utils/file_properties.py
+++ b/WebStreamer/utils/file_properties.py
@@ -70,6 +70,8 @@ def get_name(media_msg: Message | FileId) -> str:
     if not file_name:
         if isinstance(media_msg, Message) and media_msg.media:
             media_type = media_msg.media.value
+        elif media_msg.file_type:
+            media_type = media_msg.file_type.name.lower()
         else:
             media_type = "file"
 

--- a/WebStreamer/utils/file_properties.py
+++ b/WebStreamer/utils/file_properties.py
@@ -5,6 +5,7 @@ from pyrogram.file_id import FileId
 from typing import Any, Optional, Union
 from pyrogram.raw.types.messages import Messages
 from WebStreamer.server.exceptions import FIleNotFound
+from datetime import datetime
 
 
 async def parse_file_id(message: "Message") -> Optional[FileId]:
@@ -56,6 +57,27 @@ def get_hash(media_msg: Union[str, Message], length: int) -> str:
     long_hash = hashlib.sha256(unique_id.encode("UTF-8")).hexdigest()
     return long_hash[:length]
 
+
 def get_name(media_msg: Message) -> str:
     media = get_media_from_message(media_msg)
-    return getattr(media, 'file_name', "") or ""
+    file_name = getattr(media, 'file_name', "") or ""
+
+    if not file_name:
+        if media_msg.media and media_msg.media.value:
+            media_type = media_msg.media.value
+        else:
+            media_type = "file"
+
+        formats = {
+            "photo": "jpg", "audio": "mp3", "voice": "ogg",
+            "video": "mp4", "animation": "mp4", "video_note": "mp4",
+            "sticker": "webp"
+        }
+
+        ext = formats.get(media_type)
+        ext = "." + ext if ext else ""
+
+        date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        file_name = f"{media_type}-{date}{ext}"
+
+    return file_name

--- a/WebStreamer/utils/file_properties.py
+++ b/WebStreamer/utils/file_properties.py
@@ -58,12 +58,17 @@ def get_hash(media_msg: Union[str, Message], length: int) -> str:
     return long_hash[:length]
 
 
-def get_name(media_msg: Message) -> str:
-    media = get_media_from_message(media_msg)
-    file_name = getattr(media, 'file_name', "") or ""
+def get_name(media_msg: Message | FileId) -> str:
+
+    if isinstance(media_msg, Message):
+        media = get_media_from_message(media_msg)
+        file_name = getattr(media, "file_name", "")
+
+    elif isinstance(media_msg, FileId):
+        file_name = getattr(media_msg, "file_name", "")
 
     if not file_name:
-        if media_msg.media and media_msg.media.value:
+        if isinstance(media_msg, Message) and media_msg.media:
             media_type = media_msg.media.value
         else:
             media_type = "file"


### PR DESCRIPTION
This doesn't fix the name that the server returns when downloading the file, but downloads. Fix this in `WebStreamer\server\stream_routes.py` if possible.