### PR TITLE
fix: building wheel for tgcrypto fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY requirements.txt ./
 
+RUN apk add build-base
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
building the docker image in the current version is unsuccessful, and results in the following error:
```
#0 9.090   × Building wheel for TgCrypto (pyproject.toml) did not run successfully.
#0 9.090   │ exit code: 1
#0 9.090   ╰─> [22 lines of output]
#0 9.090       running bdist_wheel
#0 9.090       running build
#0 9.090       running build_py
#0 9.090       creating build
#0 9.090       creating build/lib.linux-aarch64-cpython-39
#0 9.090       creating build/lib.linux-aarch64-cpython-39/tests
#0 9.090       copying tests/__init__.py -> build/lib.linux-aarch64-cpython-39/tests
#0 9.090       creating build/lib.linux-aarch64-cpython-39/tests/ctr
#0 9.090       copying tests/ctr/test_ctr.py -> build/lib.linux-aarch64-cpython-39/tests/ctr
#0 9.090       copying tests/ctr/__init__.py -> build/lib.linux-aarch64-cpython-39/tests/ctr
#0 9.090       creating build/lib.linux-aarch64-cpython-39/tests/cbc
#0 9.090       copying tests/cbc/test_cbc.py -> build/lib.linux-aarch64-cpython-39/tests/cbc
#0 9.090       copying tests/cbc/__init__.py -> build/lib.linux-aarch64-cpython-39/tests/cbc
#0 9.090       creating build/lib.linux-aarch64-cpython-39/tests/ige
#0 9.090       copying tests/ige/__init__.py -> build/lib.linux-aarch64-cpython-39/tests/ige
#0 9.090       copying tests/ige/test_ige.py -> build/lib.linux-aarch64-cpython-39/tests/ige
#0 9.090       running build_ext
#0 9.090       building 'tgcrypto' extension
#0 9.090       creating build/temp.linux-aarch64-cpython-39
#0 9.090       creating build/temp.linux-aarch64-cpython-39/tgcrypto
#0 9.090       gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.9 -c tgcrypto/aes256.c -o build/temp.linux-aarch64-cpython-39/tgcrypto/aes256.o
#0 9.090       error: command 'gcc' failed: No such file or directory
#0 9.090       [end of output]
#0 9.090   
#0 9.090   note: This error originates from a subprocess, and is likely not a problem with pip.
#0 9.091   ERROR: Failed building wheel for TgCrypto
#0 9.092 Successfully built pyaes
#0 9.092 Failed to build TgCrypto
#0 9.093 ERROR: Could not build wheels for TgCrypto, which is required to install pyproject.toml-based projects
```

this pull request adds `apk add build-base` in the Dockerfile and allows the image to be built successfully.