### PR TITLE
feat: support photo message

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -23,6 +23,7 @@ func InitCache(log *zap.Logger) {
 	log = log.Named("cache")
 	gob.Register(types.File{})
 	gob.Register(tg.InputDocumentFileLocation{})
+	gob.Register(tg.InputPhotoFileLocation{})
 	defer log.Sugar().Info("Initialized")
 	cache = &Cache{cache: freecache.NewCache(10 * 1024 * 1024), log: log}
 }

--- a/internal/commands/stream.go
+++ b/internal/commands/stream.go
@@ -32,7 +32,7 @@ func supportedMediaFilter(m *types.Message) (bool, error) {
 	case *tg.MessageMediaDocument:
 		return true, nil
 	case *tg.MessageMediaPhoto:
-		return false, nil
+		return true, nil
 	case tg.MessageMediaClass:
 		return false, dispatcher.EndGroups
 	default:

--- a/internal/types/file.go
+++ b/internal/types/file.go
@@ -10,7 +10,7 @@ import (
 )
 
 type File struct {
-	Location *tg.InputDocumentFileLocation
+	Location tg.InputFileLocationClass
 	FileSize int64
 	FileName string
 	MimeType string

--- a/internal/utils/reader.go
+++ b/internal/utils/reader.go
@@ -14,7 +14,7 @@ type telegramReader struct {
 	ctx           context.Context
 	log           *zap.Logger
 	client        *gotgproto.Client
-	location      *tg.InputDocumentFileLocation
+	location      tg.InputFileLocationClass
 	start         int64
 	end           int64
 	next          func() ([]byte, error)
@@ -32,7 +32,7 @@ func (*telegramReader) Close() error {
 func NewTelegramReader(
 	ctx context.Context,
 	client *gotgproto.Client,
-	location *tg.InputDocumentFileLocation,
+	location tg.InputFileLocationClass,
 	start int64,
 	end int64,
 	contentLength int64,


### PR DESCRIPTION
This pull request introduces several changes to support handling photo messages in addition to document messages. The changes include registering new types, modifying existing functions to handle photos, and updating file location handling. Here are the most important changes:

### Support for Photo Messages:

* [`internal/cache/cache.go`](diffhunk://#diff-113f0a3ddf486bd0f7ee93e06851fe642139355ce485bd7acd848729688962b2R26): Registered `tg.InputPhotoFileLocation` to support photo messages.
* [`internal/commands/stream.go`](diffhunk://#diff-83df84485020687abc086bf918c10fa35511a55996fde8281b012ed5ce078aaeL35-R35): Updated `supportedMediaFilter` to return true for `tg.MessageMediaPhoto` and adjusted `sendLink` function to remove redundant error handling. [[1]](diffhunk://#diff-83df84485020687abc086bf918c10fa35511a55996fde8281b012ed5ce078aaeL35-R35) [[2]](diffhunk://#diff-83df84485020687abc086bf918c10fa35511a55996fde8281b012ed5ce078aaeL68-L72)
* [`internal/routes/stream.go`](diffhunk://#diff-b0448390b4f83573bc3fe7001cbf63d1905875e7b119be9cbe4979b89e94a88eR62-R89): Added logic to handle photo messages in `getStreamRoute`, including fetching the file and setting appropriate headers. [[1]](diffhunk://#diff-b0448390b4f83573bc3fe7001cbf63d1905875e7b119be9cbe4979b89e94a88eR62-R89) [[2]](diffhunk://#diff-b0448390b4f83573bc3fe7001cbf63d1905875e7b119be9cbe4979b89e94a88eL101-L104)
* [`internal/utils/helpers.go`](diffhunk://#diff-3056bad7e428f6b0c8b491100ce536d0bf34af98830a8eee6700ab08feb1e9e5L70-R95): Implemented support for photo media in `FileFromMedia` and updated `FileFromMessage` to handle photos. [[1]](diffhunk://#diff-3056bad7e428f6b0c8b491100ce536d0bf34af98830a8eee6700ab08feb1e9e5L70-R95) [[2]](diffhunk://#diff-3056bad7e428f6b0c8b491100ce536d0bf34af98830a8eee6700ab08feb1e9e5L102)

### File Location Handling:

* [`internal/types/file.go`](diffhunk://#diff-dd26da17611eb1c5a2b7eaf151edef428d7f43f194d6d22ed8ec0d9479d1b0f4L13-R13): Changed `Location` field in `File` struct to use `tg.InputFileLocationClass` instead of `tg.InputDocumentFileLocation`.
* [`internal/utils/reader.go`](diffhunk://#diff-69f82dd7cf85df62e74cf1a9ff3775aaf0383efe3f78d8c1653a6f2d9a145943L17-R17): Updated `telegramReader` to use `tg.InputFileLocationClass` for `location` field. [[1]](diffhunk://#diff-69f82dd7cf85df62e74cf1a9ff3775aaf0383efe3f78d8c1653a6f2d9a145943L17-R17) [[2]](diffhunk://#diff-69f82dd7cf85df62e74cf1a9ff3775aaf0383efe3f78d8c1653a6f2d9a145943L35-R35)

These changes collectively enhance the system's capability to handle photo messages, ensuring proper registration, filtering, and processing of photo files.